### PR TITLE
libpsyal 4.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
 
 requirements:
   build:
-    - patch
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ requirements:
 test:
   source_files:
     - libpysal/weights/tests/test_weights.py
+    - pyproject.toml
   imports:
     - libpysal
     - libpysal.cg
@@ -63,7 +64,6 @@ test:
       # smoke test on omly test weight due to the rest of the test using all relative imports to the source code.
       # skipping test_plot due to reading a datafile, importing matplotlib and warnings causing overall test to fail.
     - pytest libpysal/weights/tests/test_weights.py -k "not test_plot"
-    - pyproject.toml
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,7 @@ test:
       # smoke test on omly test weight due to the rest of the test using all relative imports to the source code.
       # skipping test_plot due to reading a datafile, importing matplotlib and warnings causing overall test to fail.
     - pytest libpysal/weights/tests/test_weights.py -k "not test_plot"
+    - pyproject.toml
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools_scm
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-    - beautifulsoup4
+    - beautifulsoup4 >=4.10
     - scipy >=1.8
     - numpy >=1.22
     - pandas >=1.4
@@ -30,7 +30,7 @@ requirements:
     - requests >=2.27
     - shapely >=2.0.1
     - scikit-learn >=1.1
-    - geopandas
+    - geopandas >=0.10.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,9 +66,6 @@ test:
   requires:
     - pip
     - pytest
-    - numpy
-    - scipy
-    - geopandas
 
 about:
   home: https://pysal.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,13 @@ requirements:
     - shapely >=2.0.1
     - scikit-learn >=1.1
     - geopandas >=0.10.0
+  run_constrained:
+    - joblib >=1.2
+    - networkx >=2.7
+    - numba >=0.55
+    - pyarrow >=7.0
+    - sqlalchemy >=2.0
+    - xarray >=2022.3
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,6 @@ requirements:
     - shapely >=2.0.1
     - scikit-learn >=1.1
     - geopandas
-    # not in the metadata but need
-    - bs4
 
 test:
   imports:
@@ -46,14 +44,13 @@ test:
     - libpysal.io.tests
     - libpysal.io.util
     - libpysal.weights
-# pip check is not smart enough to know that an import name is not the package name :-(
-# commands:
-#  - pip check
-# requires:
-#  - pip
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
-  home: http://pysal.org
+  home: https://pysal.org
   summary: Core components of PySAL A library of spatial analysis functions
   description: |
     libpysal offers four modules that form the building blocks in many upstream 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<310]
+  skip: True  # [py<310 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,16 +7,19 @@ package:
 source:
   url: https://pypi.io/packages/source/l/libpysal/libpysal-{{ version }}.tar.gz
   sha256: 4d3127802c7c06289ffb211d10202dd8d14b10039a81249920769ce4b987e3b5
+  patches:
+    - patches/0001-test_weights_relative_to_absolute.patch
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<310 or s390x]
 
 requirements:
+  build:
+    - patch
   host:
     - python
     - pip
-    - pytest-runner
     - setuptools
     - wheel
   run:
@@ -33,6 +36,8 @@ requirements:
     - geopandas >=0.10.0
 
 test:
+  source_files:
+    - libpysal/weights/tests/test_weights.py
   imports:
     - libpysal
     - libpysal.cg
@@ -46,8 +51,15 @@ test:
     - libpysal.weights
   commands:
     - pip check
+      # smoke test on omly test weight due to the rest of the test using all relative imports to the source code.
+      # skipping test_plot due to reading a datafile, importing matplotlib and warnings causing overall test to fail.
+    - pytest libpysal/weights/tests/test_weights.py -k "not test_plot"
   requires:
     - pip
+    - pytest
+    - numpy
+    - scipy
+    - geopandas
 
 about:
   home: https://pysal.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.5.1" %}
+{% set version = "4.10" %}
 
 package:
   name: libpysal
@@ -6,28 +6,31 @@ package:
 
 source:
   url: https://pypi.io/packages/source/l/libpysal/libpysal-{{ version }}.tar.gz
-  sha256: 60bbe3291aceccdf29c8ad9cf2eec76633f67ab7756d0353853f7f34a756ae12
-
+  sha256: 4d3127802c7c06289ffb211d10202dd8d14b10039a81249920769ce4b987e3b5
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<310]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - pytest-runner
     - setuptools
     - wheel
   run:
-    - python >=3.7
+    - python
     - beautifulsoup4
-    - scipy >=0.11
-    - numpy >=1.3
-    - pandas
-    - requests
-    - jinja2
+    - scipy >=1.8
+    - numpy >=1.22
+    - pandas >=1.4
+    - packaging >=22
+    - platformdirs >=2.0.2
+    - requests >=2.27
+    - shapely >=2.0.1
+    - scikit-learn >=1.1
+    - geopandas
     # not in the metadata but need
     - bs4
 
@@ -51,10 +54,15 @@ test:
 
 about:
   home: http://pysal.org
+  summary: Core components of PySAL A library of spatial analysis functions
+  description: |
+    libpysal offers four modules that form the building blocks in many upstream 
+    packages in the PySAL family. Spatial Weights: libpysal.weights. Input-and 
+    output: libpysal.io. Computational geometry: libpysal.cg. Built-in example 
+    datasets libpysal.examples
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  summary: Core components of PySAL A library of spatial analysis functions
   dev_url: https://github.com/pysal/libpysal
   doc_url: https://pysal.org/libpysal/
 

--- a/recipe/patches/0001-test_weights_relative_to_absolute.patch
+++ b/recipe/patches/0001-test_weights_relative_to_absolute.patch
@@ -1,0 +1,37 @@
+From 7f4f8343abbfe70a993275f318817635af6910cb Mon Sep 17 00:00:00 2001
+From: Udo-Peter Steyer <ous8292@gmail.com>
+Date: Thu, 30 May 2024 12:44:15 -0500
+Subject: [PATCH] test_weights_relative_to_absolute
+
+---
+ libpysal/weights/tests/test_weights.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/libpysal/weights/tests/test_weights.py b/libpysal/weights/tests/test_weights.py
+index 0b860500..40990641 100644
+--- a/libpysal/weights/tests/test_weights.py
++++ b/libpysal/weights/tests/test_weights.py
+@@ -7,13 +7,13 @@ import numpy as np
+ import pytest
+ import scipy.sparse
+ 
+-from ... import examples
+-from ...io.fileio import FileIO
+-from .. import util
+-from ..contiguity import Rook
+-from ..distance import KNN
+-from ..util import WSP2W, lat2W
+-from ..weights import WSP, W, _LabelEncoder
++from libpysal import examples
++from libpysal.io.fileio import FileIO
++from libpysal.weights import util
++from libpysal.weights.contiguity import Rook
++from libpysal.weights.distance import KNN
++from libpysal.weights.util import WSP2W, lat2W
++from libpysal.weights.weights import WSP, W, _LabelEncoder
+ 
+ 
+ class TestW:
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
libpsyal 4.10.0 :snowflake:

**Destination channel:** defaults

### Links

- [PKG-4610](https://anaconda.atlassian.net/browse/PKG-4610) 
- [Upstream repository](https://github.com/pysal/libpysal/tree/v4.10)
- [Upstream changelog/diff](https://github.com/pysal/libpysal/compare/v4.5.1.post2...v4.10)


### Explanation of changes:

- bump version and SHA
- removed noarch
- added skip for python 3.10 and s390x
- added script flags
- removed python pinnings under host and run requirements
- updated run dependencies and pinnings
- added test commands and requires back in
- moved summary
- added in about description
- update home address
- added tests and patch for tests


[PKG-4610]: https://anaconda.atlassian.net/browse/PKG-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ