### PR TITLE
libpysal 4.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   patches:
     - patches/0001-test_weights_relative_to_absolute.patch
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<310 or s390x]
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
 
 requirements:
   build:


### PR DESCRIPTION
libpysal 4.10 build 1


**Destination channel:** defaults

### Links

- [PKG-4610](https://anaconda.atlassian.net/browse/PKG-4610) 
- [Upstream repository](https://github.com/pysal/libpysal/tree/v4.10)
- [Upstream changelog/diff](https://github.com/pysal/libpysal/compare/v4.5.1.post2...v4.10)
- Relevant PRs:
  - original pr: https://github.com/AnacondaRecipes/libpysal-feedstock/pull/4
  - dependency for: https://github.com/AnacondaRecipes/momepy-feedstock/pull/1

### Explanation of changes:
- Already build and merged, but not uploaded to defaults in [PR 4](https://github.com/AnacondaRecipes/libpysal-feedstock/pull/4)
- reason for rebuild:
needed to add SETUPTOOLS_SCM_PRETEND_VERSION for `mompey` `pip check` test. 
Setuptools scm is not able to find a version because the build is not from a git repo. So it sets 0.0.0. 



[PKG-4610]: https://anaconda.atlassian.net/browse/PKG-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ