### PR TITLE
libpysal 4.10 [test geopandas 1.0.1]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/0b5fc8c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
+  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/0b5fc8c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,13 +14,14 @@ source:
 build:
   number: 2
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  # libpysal upstream moved on to py310, using the new typing system
   skip: True  # [py<310 or s390x]
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
 
 requirements:
   build:
-    - patch  # [not win]
+    - patch     # [not win]
     - m2-patch  # [win]
   host:
     - python
@@ -63,10 +64,14 @@ test:
     - libpysal.io.tests
     - libpysal.io.util
     - libpysal.weights
+    - libpysal.common
   commands:
     - pip check
       # check that pip gets the correct version 
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - python -c "from libpysal.examples import summary; print(summary())"
+    - python -c "from libpysal.examples import available; print(available())"
+    - python -c "from libpysal.examples import get_path; example_path = get_path('10740.shp'); assert(example_path is not None)"
       # smoke test on only test weight due to the rest of the test using all relative imports to the source code.
       # skipping test_plot due to reading a datafile, importing matplotlib and warnings causing overall test to fail.
     - pytest libpysal/weights/tests/test_weights.py -k "not test_plot"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,18 @@
+{% set name = "libpysal" %}
 {% set version = "4.10" %}
 
 package:
-  name: libpysal
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/l/libpysal/libpysal-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 4d3127802c7c06289ffb211d10202dd8d14b10039a81249920769ce4b987e3b5
   patches:
     - patches/0001-test_weights_relative_to_absolute.patch
+
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<310 or s390x]
   script_env:
@@ -63,7 +65,9 @@ test:
     - libpysal.weights
   commands:
     - pip check
-      # smoke test on omly test weight due to the rest of the test using all relative imports to the source code.
+      # check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+      # smoke test on only test weight due to the rest of the test using all relative imports to the source code.
       # skipping test_plot due to reading a datafile, importing matplotlib and warnings causing overall test to fail.
     - pytest libpysal/weights/tests/test_weights.py -k "not test_plot"
   requires:


### PR DESCRIPTION
libpysal 4.10 [test geopandas 1.0.1]

[PKG-6857]

dev_url (pypi): https://github.com/pysal/libpysal/tree/v4.10

conda-forge: https://github.com/conda-forge/libpysal-feedstock/blob/main/recipe/meta.yaml

pypi: https://pypi.org/project/libpysal/4.10
pypi inspector: https://inspector.pypi.io/project/libpysal/4.10

anaconda recipes: https://github.com/AnacondaRecipes/libpysal-feedstock/blob/master/recipe/meta.yaml

### Depends on

- https://github.com/AnacondaRecipes/geopandas-feedstock/pull/11

### Changes

- bump build number
- we don't have to merge this PR, it is only used to build `libpysal 4.10` with `geopandas 1.0.1` on all platforms

[PKG-6857]: https://anaconda.atlassian.net/browse/PKG-6857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ