### PR TITLE
libpysal 4.13.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libpysal" %}
-{% set version = "4.10" %}
+{% set version = "4.13.0" %}
 
 package:
   name: {{ name }}
@@ -7,15 +7,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4d3127802c7c06289ffb211d10202dd8d14b10039a81249920769ce4b987e3b5
+  sha256: 71a07f7a2e705632862c15c51af5171a42391c874a7efd6711f06c7e4e9c6f53
   patches:
     - patches/0001-test_weights_relative_to_absolute.patch
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   # libpysal upstream moved on to py310, using the new typing system
-  skip: True  # [py<310 or s390x]
+  skip: True  # [py<310]
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
 


### PR DESCRIPTION
libpysal 4.13.0 

**Destination channel:** Defaults

### Links

- [PKG-8174]
- dev_url:        https://github.com/pysal/libpysal/tree/v4.13.0
- conda_forge:    https://github.com/conda-forge/libpysal-feedstock
- pypi:           https://pypi.org/project/libpysal/4.13.0
- pypi inspector: https://inspector.pypi.io/project/libpysal/4.13.0

### Related PRs
- Dependency for: https://github.com/AnacondaRecipes/pointpats-feedstock/pull/1

### Explanation of changes:

- new version number
- required py313 libpysal for pointpats.


[PKG-8174]: https://anaconda.atlassian.net/browse/PKG-8174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ