### PR TITLE
Update version to 4.14.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libpysal" %}
-{% set version = "4.13.0" %}
+{% set version = "4.14.1" %}
 
 package:
   name: {{ name }}
@@ -7,22 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 71a07f7a2e705632862c15c51af5171a42391c874a7efd6711f06c7e4e9c6f53
+  sha256: 84a0a832178e57b54f7da35f1c3385c1eaf99016ec8ff819add3b89d36aaff1c
   patches:
     - patches/0001-test_weights_relative_to_absolute.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  # libpysal upstream moved on to py310, using the new typing system
-  skip: True  # [py<310]
+  # libpysal upstream moved on to py311, using the new typing system
+  skip: True  # [py<311]
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
 
 requirements:
-  build:
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -31,16 +28,16 @@ requirements:
     - wheel
   run:
     - python
-    - beautifulsoup4 >=4.10
-    - scipy >=1.8
-    - numpy >=1.22
-    - pandas >=1.4
-    - packaging >=22
-    - platformdirs >=2.0.2
-    - requests >=2.27
-    - shapely >=2.0.1
-    - scikit-learn >=1.1
-    - geopandas >=0.10.0
+    - beautifulsoup4 >=4.13.0
+    - scipy >=1.12
+    - numpy >=1.26.0
+    - pandas >=2.1.0
+    - packaging >=23.2
+    - platformdirs >=3.11.0
+    - requests >=2.32.0
+    - shapely >=2.0
+    - scikit-learn >=1.4.0
+    - geopandas >=0.14.0
   run_constrained:
     - joblib >=1.2
     - networkx >=2.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   dev_url: https://github.com/pysal/libpysal
-  doc_url: https://pysal.org/libpysal/
+  doc_url: https://pysal.org/libpysal
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libpysal 4.14.1

**Destination channel:** defaults

### Links

- [PKG-13091](https://anaconda.atlassian.net/browse/PKG-13091) 
- [Upstream repository](https://github.com/pysal/libpysal)

### Explanation of changes:
- New version number
- Updating dependencies


[PKG-13091]: https://anaconda.atlassian.net/browse/PKG-13091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ